### PR TITLE
🎨 improve Gemfile updates during kettle-dev-setup (more)

### DIFF
--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -1,7 +1,7 @@
 {
-  "lib/kettle/dev.rb:261745226": [
-    [64, 17, 2, "ThreadSafety/MutableClassInstanceVariable: Freeze mutable objects assigned to class instance variables.", 5862883],
-    [75, 7, 16, "Lint/RescueException: Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?", 2127134117]
+  "lib/kettle/dev.rb:3349086928": [
+    [65, 17, 2, "ThreadSafety/MutableClassInstanceVariable: Freeze mutable objects assigned to class instance variables.", 5862883],
+    [76, 7, 16, "Lint/RescueException: Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?", 2127134117]
   ],
   "lib/kettle/dev/tasks/ci_task.rb:4072951873": [
     [268, 26, 10, "ThreadSafety/NewThread: Avoid starting new threads.", 3411682361],
@@ -168,7 +168,7 @@
     [1491, 7, 58, "RSpec/MultipleExpectations: Example has too many expectations [3/1].", 1054286736],
     [1522, 7, 69, "RSpec/MultipleExpectations: Example has too many expectations [3/1].", 2519740787]
   ],
-  "spec/kettle/dev/setup_cli_more_spec.rb:2481923901": [
+  "spec/kettle/dev/setup_cli_more_spec.rb:1682564880": [
     [74, 7, 13, "RSpec/StubbedMock: Prefer `allow` over `expect` when configuring a response.", 2024371388]
   ],
   "spec/kettle/dev/tasks/ci_task_spec.rb:3449714240": [

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: .
   specs:
-    kettle-dev (1.1.11)
+    kettle-dev (1.1.12)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/kettle/dev.rb
+++ b/lib/kettle/dev.rb
@@ -26,6 +26,7 @@ module Kettle
     autoload :PreReleaseCLI, "kettle/dev/pre_release_cli"
     autoload :SetupCLI, "kettle/dev/setup_cli"
     autoload :TemplateHelpers, "kettle/dev/template_helpers"
+    autoload :ModularGemfiles, "kettle/dev/modular_gemfiles"
     autoload :Version, "kettle/dev/version"
     autoload :Versioning, "kettle/dev/versioning"
 

--- a/lib/kettle/dev/modular_gemfiles.rb
+++ b/lib/kettle/dev/modular_gemfiles.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Kettle
+  module Dev
+    # Utilities for copying modular Gemfiles and related directories
+    # in a DRY fashion. Used by both the template rake task and the
+    # setup CLI to ensure gemfiles/modular/* are present before use.
+    module ModularGemfiles
+      MODULAR_GEMFILE_DIR = "gemfiles/modular"
+
+      module_function
+
+      # Copy the modular gemfiles and nested directories from the gem
+      # checkout into the target project, prompting where appropriate
+      # via the provided helpers.
+      #
+      # @param helpers [Kettle::Dev::TemplateHelpers] helper API
+      # @param project_root [String] destination project root
+      # @param gem_checkout_root [String] kettle-dev checkout root (source)
+      # @param min_ruby [Gem::Version, nil] minimum Ruby version (for style.gemfile tuning)
+      # @return [void]
+      def sync!(helpers:, project_root:, gem_checkout_root:, min_ruby: nil)
+        # 4a) gemfiles/modular/*.gemfile except style.gemfile (handled below)
+        modular_gemfiles = %w[
+          coverage
+          debug
+          documentation
+          injected
+          optional
+          runtime_heads
+          x_std_libs
+        ]
+        modular_gemfiles.each do |base|
+          modular_gemfile = "#{base}.gemfile"
+          src = helpers.prefer_example(File.join(gem_checkout_root, MODULAR_GEMFILE_DIR, modular_gemfile))
+          dest = File.join(project_root, MODULAR_GEMFILE_DIR, modular_gemfile)
+          helpers.copy_file_with_prompt(src, dest, allow_create: true, allow_replace: true)
+        end
+
+        # 4b) gemfiles/modular/style.gemfile with dynamic rubocop constraints
+        modular_gemfile = "style.gemfile"
+        src = helpers.prefer_example(File.join(gem_checkout_root, MODULAR_GEMFILE_DIR, modular_gemfile))
+        dest = File.join(project_root, MODULAR_GEMFILE_DIR, modular_gemfile)
+        if File.basename(src).sub(/\.example\z/, "") == "style.gemfile"
+          helpers.copy_file_with_prompt(src, dest, allow_create: true, allow_replace: true) do |content|
+            # Adjust rubocop-lts constraint based on min_ruby
+            version_map = [
+              [Gem::Version.new("1.8"), "~> 0.1"],
+              [Gem::Version.new("1.9"), "~> 2.0"],
+              [Gem::Version.new("2.0"), "~> 4.0"],
+              [Gem::Version.new("2.1"), "~> 6.0"],
+              [Gem::Version.new("2.2"), "~> 8.0"],
+              [Gem::Version.new("2.3"), "~> 10.0"],
+              [Gem::Version.new("2.4"), "~> 12.0"],
+              [Gem::Version.new("2.5"), "~> 14.0"],
+              [Gem::Version.new("2.6"), "~> 16.0"],
+              [Gem::Version.new("2.7"), "~> 18.0"],
+              [Gem::Version.new("3.0"), "~> 20.0"],
+              [Gem::Version.new("3.1"), "~> 22.0"],
+              [Gem::Version.new("3.2"), "~> 24.0"],
+              [Gem::Version.new("3.3"), "~> 26.0"],
+              [Gem::Version.new("3.4"), "~> 28.0"],
+            ]
+            new_constraint = nil
+            rubocop_ruby_gem_version = nil
+            ruby1_8 = version_map.first
+            begin
+              if min_ruby
+                version_map.reverse_each do |min, req|
+                  if min_ruby >= min
+                    new_constraint = req
+                    rubocop_ruby_gem_version = min.segments.join("_")
+                    break
+                  end
+                end
+              end
+              if !new_constraint || !rubocop_ruby_gem_version
+                # A gem with no declared minimum ruby is effectively >= 1.8.7
+                new_constraint = ruby1_8[1]
+                rubocop_ruby_gem_version = ruby1_8[0].segments.join("_")
+              end
+            rescue StandardError => e
+              Kettle::Dev.debug_error(e, __method__) if defined?(Kettle::Dev.debug_error)
+              # ignore, use default
+            ensure
+              new_constraint ||= ruby1_8[1]
+              rubocop_ruby_gem_version ||= ruby1_8[0].segments.join("_")
+            end
+            if new_constraint && rubocop_ruby_gem_version
+              token = "{RUBOCOP|LTS|CONSTRAINT}"
+              content.gsub!(token, new_constraint) if content.include?(token)
+              token = "{RUBOCOP|RUBY|GEM}"
+              content.gsub!(token, "rubocop-ruby#{rubocop_ruby_gem_version}") if content.include?(token)
+            end
+            content
+          end
+        else
+          helpers.copy_file_with_prompt(src, dest, allow_create: true, allow_replace: true)
+        end
+
+        # 4c) Copy modular directories with nested/versioned files
+        %w[erb mutex_m stringio x_std_libs].each do |dir|
+          src_dir = File.join(gem_checkout_root, MODULAR_GEMFILE_DIR, dir)
+          dest_dir = File.join(project_root, MODULAR_GEMFILE_DIR, dir)
+          helpers.copy_dir_with_prompt(src_dir, dest_dir)
+        end
+      end
+    end
+  end
+end

--- a/lib/kettle/dev/setup_cli.rb
+++ b/lib/kettle/dev/setup_cli.rb
@@ -32,6 +32,7 @@ module Kettle
         prechecks!
         ensure_dev_deps!
         ensure_gemfile_from_example!
+        ensure_modular_gemfiles!
         ensure_bin_setup!
         ensure_rakefile!
         run_bin_setup!
@@ -255,6 +256,26 @@ module Kettle
         new_content = target + additions.join("\n") + "\n"
         File.write(target_path, new_content)
         say("Updated Gemfile with entries from Gemfile.example (added #{additions.size}).")
+      end
+
+      # 3c. Ensure gemfiles/modular/* are present (copied like template task)
+      def ensure_modular_gemfiles!
+        helpers = Kettle::Dev::TemplateHelpers
+        project_root = helpers.project_root
+        gem_checkout_root = helpers.gem_checkout_root
+        # Gather min_ruby for style.gemfile adjustments
+        min_ruby = begin
+          md = helpers.gemspec_metadata(project_root)
+          md[:min_ruby]
+        rescue StandardError
+          nil
+        end
+        Kettle::Dev::ModularGemfiles.sync!(
+          helpers: helpers,
+          project_root: project_root,
+          gem_checkout_root: gem_checkout_root,
+          min_ruby: min_ruby,
+        )
       end
 
       # 5. Ensure Rakefile matches example (replace or create)

--- a/lib/kettle/dev/tasks/template_task.rb
+++ b/lib/kettle/dev/tasks/template_task.rb
@@ -104,91 +104,13 @@ module Kettle
             allow_replace: true,
           )
 
-          # 4a) gemfiles/modular/*.gemfile
-          #     from gem's gemfiles/modular,
-          #     except `style.gemfile` which has special handling below
-          modular_gemfiles = %w[
-            coverage
-            debug
-            documentation
-            injected
-            optional
-            runtime_heads
-            x_std_libs
-          ]
-          modular_gemfiles.each do |base|
-            modular_gemfile = "#{base}.gemfile"
-            src = helpers.prefer_example(File.join(gem_checkout_root, MODULAR_GEMFILE_DIR, modular_gemfile))
-            dest = File.join(project_root, MODULAR_GEMFILE_DIR, modular_gemfile)
-            helpers.copy_file_with_prompt(src, dest, allow_create: true, allow_replace: true)
-          end
-
-          # 4b) gemfiles/modular/style.gemfile
-          modular_gemfile = "style.gemfile"
-          src = helpers.prefer_example(File.join(gem_checkout_root, MODULAR_GEMFILE_DIR, modular_gemfile))
-          dest = File.join(project_root, MODULAR_GEMFILE_DIR, modular_gemfile)
-          if File.basename(src).sub(/\.example\z/, "") == "style.gemfile"
-            helpers.copy_file_with_prompt(src, dest, allow_create: true, allow_replace: true) do |content|
-              # Adjust rubocop-lts constraint based on min_ruby
-              version_map = [
-                [Gem::Version.new("1.8"), "~> 0.1"],
-                [Gem::Version.new("1.9"), "~> 2.0"],
-                [Gem::Version.new("2.0"), "~> 4.0"],
-                [Gem::Version.new("2.1"), "~> 6.0"],
-                [Gem::Version.new("2.2"), "~> 8.0"],
-                [Gem::Version.new("2.3"), "~> 10.0"],
-                [Gem::Version.new("2.4"), "~> 12.0"],
-                [Gem::Version.new("2.5"), "~> 14.0"],
-                [Gem::Version.new("2.6"), "~> 16.0"],
-                [Gem::Version.new("2.7"), "~> 18.0"],
-                [Gem::Version.new("3.0"), "~> 20.0"],
-                [Gem::Version.new("3.1"), "~> 22.0"],
-                [Gem::Version.new("3.2"), "~> 24.0"],
-                [Gem::Version.new("3.3"), "~> 26.0"],
-                [Gem::Version.new("3.4"), "~> 28.0"],
-              ]
-              new_constraint = nil
-              rubocop_ruby_gem_version = nil
-              ruby1_8 = version_map.first
-              begin
-                if min_ruby
-                  version_map.reverse_each do |min, req|
-                    if min_ruby >= min
-                      new_constraint = req
-                      rubocop_ruby_gem_version = min.segments.join("_")
-                      break
-                    end
-                  end
-                end
-                if !new_constraint || !rubocop_ruby_gem_version
-                  # A gem with no declared minimum ruby is effectively >= 1.8.7
-                  new_constraint = ruby1_8[1]
-                  rubocop_ruby_gem_version = ruby1_8[0].segments.join("_")
-                end
-              rescue StandardError => e
-                Kettle::Dev.debug_error(e, __method__)
-                # ignore, use default
-              ensure
-                new_constraint ||= ruby1_8[1]
-                rubocop_ruby_gem_version ||= ruby1_8[0].segments.join("_")
-              end
-              if new_constraint && rubocop_ruby_gem_version
-                token = "{RUBOCOP|LTS|CONSTRAINT}"
-                content.gsub!(token, new_constraint) if content.include?(token)
-                token = "{RUBOCOP|RUBY|GEM}"
-                content.gsub!(token, "rubocop-ruby#{rubocop_ruby_gem_version}") if content.include?(token)
-              end
-            end
-          else
-            helpers.copy_file_with_prompt(src, dest, allow_create: true, allow_replace: true)
-          end
-
-          # 4c) Copy modular directories with nested/versioned files
-          %w[erb mutex_m stringio x_std_libs].each do |dir|
-            src_dir = File.join(gem_checkout_root, MODULAR_GEMFILE_DIR, dir)
-            dest_dir = File.join(project_root, MODULAR_GEMFILE_DIR, dir)
-            helpers.copy_dir_with_prompt(src_dir, dest_dir)
-          end
+          # 4) gemfiles/modular/* and nested directories (delegated for DRYness)
+          Kettle::Dev::ModularGemfiles.sync!(
+            helpers: helpers,
+            project_root: project_root,
+            gem_checkout_root: gem_checkout_root,
+            min_ruby: min_ruby,
+          )
 
           # 5) spec/spec_helper.rb (no create)
           dest_spec_helper = File.join(project_root, "spec/spec_helper.rb")

--- a/lib/kettle/dev/version.rb
+++ b/lib/kettle/dev/version.rb
@@ -6,7 +6,7 @@ module Kettle
     module Version
       # The gem version.
       # @return [String]
-      VERSION = "1.1.11"
+      VERSION = "1.1.12"
 
       module_function
 

--- a/sig/kettle/dev/modular_gemfiles.rbs
+++ b/sig/kettle/dev/modular_gemfiles.rbs
@@ -1,0 +1,12 @@
+module Kettle
+  module Dev
+    module ModularGemfiles
+      def self.sync!: (
+        helpers: untyped,
+        project_root: String,
+        gem_checkout_root: String,
+        min_ruby: untyped
+      ) -> void
+    end
+  end
+end

--- a/spec/kettle/dev/modular_gemfiles_spec.rb
+++ b/spec/kettle/dev/modular_gemfiles_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe Kettle::Dev::ModularGemfiles do
+  include_context "with stubbed env"
+
+  before do
+    require "kettle/dev"
+  end
+
+  it "exposes sync! and performs copy calls via helpers" do
+    helpers = Kettle::Dev::TemplateHelpers
+    Dir.mktmpdir do |proj|
+      Dir.mktmpdir do |gemroot|
+        # Create a minimal source tree for modular files
+        src_dir = File.join(gemroot, described_class::MODULAR_GEMFILE_DIR)
+        FileUtils.mkdir_p(src_dir)
+        %w[coverage debug documentation injected optional runtime_heads x_std_libs].each do |base|
+          File.write(File.join(src_dir, "#{base}.gemfile"), "# #{base}\n")
+        end
+        File.write(File.join(src_dir, "style.gemfile"), "gem 'rubocop-lts', '{RUBOCOP|LTS|CONSTRAINT}'\n# {RUBOCOP|RUBY|GEM}\n")
+        %w[erb mutex_m stringio x_std_libs].each do |dir|
+          FileUtils.mkdir_p(File.join(src_dir, dir))
+          File.write(File.join(src_dir, dir, "placeholder"), "ok\n")
+        end
+
+        # Stub helpers.project_root and gem_checkout_root to these temp dirs
+        allow(helpers).to receive_messages(
+          project_root: proj,
+          gem_checkout_root: gemroot,
+          ask: true,
+        )
+
+        expect {
+          described_class.sync!(helpers: helpers, project_root: proj, gem_checkout_root: gemroot, min_ruby: Gem::Version.new("3.2"))
+        }.not_to raise_error
+
+        # Verify a couple of outputs exist
+        expect(File).to exist(File.join(proj, described_class::MODULAR_GEMFILE_DIR, "coverage.gemfile"))
+        expect(File).to exist(File.join(proj, described_class::MODULAR_GEMFILE_DIR, "style.gemfile"))
+        expect(File.read(File.join(proj, described_class::MODULAR_GEMFILE_DIR, "style.gemfile"))).to include("rubocop-lts")
+        expect(File).to exist(File.join(proj, described_class::MODULAR_GEMFILE_DIR, "erb", "placeholder"))
+      end
+    end
+  end
+end

--- a/spec/kettle/dev/setup_cli_more_spec.rb
+++ b/spec/kettle/dev/setup_cli_more_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Kettle::Dev::SetupCLI do
       cli = described_class.allocate
       cli.instance_variable_set(:@argv, [])
       allow(cli).to receive(:parse!)
-      %i[prechecks! ensure_dev_deps! ensure_gemfile_from_example! ensure_bin_setup! ensure_rakefile! run_bin_setup! run_bundle_binstubs! commit_bootstrap_changes! run_kettle_install!].each do |m|
+      %i[prechecks! ensure_dev_deps! ensure_gemfile_from_example! ensure_modular_gemfiles! ensure_bin_setup! ensure_rakefile! run_bin_setup! run_bundle_binstubs! commit_bootstrap_changes! run_kettle_install!].each do |m|
         expect(cli).to receive(m).ordered
       end
       expect { cli.run! }.not_to raise_error


### PR DESCRIPTION
The modular gemfiles have to be copied in order to eval them in the Gemfile.