### PR TITLE
🐛 include .rubocop_rspec.yml during install / template task's file copy

### DIFF
--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -8,10 +8,10 @@
     [271, 13, 329, "Lint/RescueException: Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?", 2809878728],
     [284, 24, 60, "ThreadSafety/NewThread: Avoid starting new threads.", 1884163423]
   ],
-  "lib/kettle/dev/template_helpers.rb:1279325672": [
-    [117, 11, 20, "ThreadSafety/DirChdir: Avoid using `Dir.chdir` due to its process-wide effect.", 645000286],
-    [134, 11, 52, "Style/IdenticalConditionalBranches: Move `preview = status_output.lines.take(10).map(&:rstrip)` out of the conditional.", 311333201],
-    [146, 11, 52, "Style/IdenticalConditionalBranches: Move `preview = status_output.lines.take(10).map(&:rstrip)` out of the conditional.", 311333201]
+  "lib/kettle/dev/template_helpers.rb:1636150029": [
+    [121, 11, 20, "ThreadSafety/DirChdir: Avoid using `Dir.chdir` due to its process-wide effect.", 645000286],
+    [138, 11, 52, "Style/IdenticalConditionalBranches: Move `preview = status_output.lines.take(10).map(&:rstrip)` out of the conditional.", 311333201],
+    [150, 11, 52, "Style/IdenticalConditionalBranches: Move `preview = status_output.lines.take(10).map(&:rstrip)` out of the conditional.", 311333201]
   ],
   "spec/kettle/dev/changelog_cli_spec.rb:1599338057": [
     [39, 9, 72, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [40].", 1904128172],
@@ -168,8 +168,8 @@
     [1491, 7, 58, "RSpec/MultipleExpectations: Example has too many expectations [3/1].", 1054286736],
     [1522, 7, 69, "RSpec/MultipleExpectations: Example has too many expectations [3/1].", 2519740787]
   ],
-  "spec/kettle/dev/setup_cli_more_spec.rb:2674107253": [
-    [81, 7, 13, "RSpec/StubbedMock: Prefer `allow` over `expect` when configuring a response.", 2024371388]
+  "spec/kettle/dev/setup_cli_more_spec.rb:1604168635": [
+    [85, 7, 13, "RSpec/StubbedMock: Prefer `allow` over `expect` when configuring a response.", 2024371388]
   ],
   "spec/kettle/dev/tasks/ci_task_spec.rb:3449714240": [
     [556, 9, 29, "RSpec/AnyInstance: Avoid stubbing using `allow_any_instance_of`.", 440176922],
@@ -179,19 +179,19 @@
   "spec/kettle/dev/tasks/template_task_spec.rb:149664963": [
     [619, 15, 24, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 196765058]
   ],
-  "spec/kettle/dev/template_helpers_spec.rb:1388125955": [
-    [671, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [673].", 3890449948],
-    [673, 11, 48, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [671].", 1824268915],
-    [712, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [714].", 3890449948],
-    [714, 11, 48, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [712].", 1824268915],
-    [777, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [780].", 3890449948],
-    [780, 11, 49, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [777].", 3989616664],
-    [797, 9, 29, "RSpec/AnyInstance: Avoid stubbing using `allow_any_instance_of`.", 835110177],
-    [823, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [825].", 3890449948],
-    [825, 11, 48, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [823].", 1824268915],
-    [841, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [845].", 3890449948],
-    [845, 11, 49, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [841].", 3989616664],
-    [911, 7, 205, "RSpec/LeakyConstantDeclaration: Stub class constant instead of declaring explicitly.", 418390978]
+  "spec/kettle/dev/template_helpers_spec.rb:464503673": [
+    [676, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [678].", 3890449948],
+    [678, 11, 48, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [676].", 1824268915],
+    [717, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [719].", 3890449948],
+    [719, 11, 48, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [717].", 1824268915],
+    [782, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [785].", 3890449948],
+    [785, 11, 49, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [782].", 3989616664],
+    [802, 9, 29, "RSpec/AnyInstance: Avoid stubbing using `allow_any_instance_of`.", 835110177],
+    [828, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [830].", 3890449948],
+    [830, 11, 48, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [828].", 1824268915],
+    [846, 11, 65, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [850].", 3890449948],
+    [850, 11, 49, "RSpec/ReceiveMessages: Use `receive_messages` instead of multiple stubs on lines [846].", 3989616664],
+    [916, 7, 205, "RSpec/LeakyConstantDeclaration: Stub class constant instead of declaring explicitly.", 418390978]
   ],
   "spec/kettle/dev/versioning_spec.rb:3465928905": [
     [53, 7, 53, "RSpec/PredicateMatcher: Prefer using `be_epic_major` matcher over `epic_major?`.", 200417834]

--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -168,8 +168,8 @@
     [1491, 7, 58, "RSpec/MultipleExpectations: Example has too many expectations [3/1].", 1054286736],
     [1522, 7, 69, "RSpec/MultipleExpectations: Example has too many expectations [3/1].", 2519740787]
   ],
-  "spec/kettle/dev/setup_cli_more_spec.rb:1974808325": [
-    [74, 7, 13, "RSpec/StubbedMock: Prefer `allow` over `expect` when configuring a response.", 2024371388]
+  "spec/kettle/dev/setup_cli_more_spec.rb:2674107253": [
+    [81, 7, 13, "RSpec/StubbedMock: Prefer `allow` over `expect` when configuring a response.", 2024371388]
   ],
   "spec/kettle/dev/tasks/ci_task_spec.rb:3449714240": [
     [556, 9, 29, "RSpec/AnyInstance: Avoid stubbing using `allow_any_instance_of`.", 440176922],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Please file a bug if you notice a violation of semantic versioning.
 ### Removed
 ### Fixed
 - include .rubocop_rspec.yml during install / template task's file copy
+- kettle-dev-setup now honors `--force` option
 ### Security
 
 ## [1.1.12] - 2025-09-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please file a bug if you notice a violation of semantic versioning.
 ### Deprecated
 ### Removed
 ### Fixed
+- include .rubocop_rspec.yml during install / template task's file copy
 ### Security
 
 ## [1.1.12] - 2025-09-09

--- a/kettle-dev.gemspec
+++ b/kettle-dev.gemspec
@@ -101,6 +101,7 @@ Gem::Specification.new do |spec|
     ".opencollective.yml",
     ".rspec",
     ".rubocop.yml",
+    ".rubocop_rspec.yml",
     ".simplecov",
     ".tool-versions",
     ".yard_gfm_support.rb",

--- a/lib/kettle/dev/setup_cli.rb
+++ b/lib/kettle/dev/setup_cli.rb
@@ -106,7 +106,11 @@ module Kettle
         parser = OptionParser.new do |opts|
           opts.banner = "Usage: kettle-dev-setup [options]"
           opts.on("--allowed=VAL", "Pass through to kettle:dev:install") { |v| @passthrough << "allowed=#{v}" }
-          opts.on("--force", "Pass through to kettle:dev:install") { @passthrough << "force=true" }
+          opts.on("--force", "Pass through to kettle:dev:install") do
+            # Ensure in-process helpers (TemplateHelpers.ask) also see force mode
+            ENV["force"] = "true"
+            @passthrough << "force=true"
+          end
           opts.on("--hook_templates=VAL", "Pass through to kettle:dev:install") { |v| @passthrough << "hook_templates=#{v}" }
           opts.on("--only=VAL", "Pass through to kettle:dev:install") { |v| @passthrough << "only=#{v}" }
           opts.on("-h", "--help", "Show help") do

--- a/lib/kettle/dev/tasks/install_task.rb
+++ b/lib/kettle/dev/tasks/install_task.rb
@@ -514,14 +514,12 @@ module Kettle
               print("Add to .gitignore now [Y/n]: ")
               answer = Kettle::Dev::InputAdapter.gets&.strip
               # Respect an explicit negative answer even when force=true
-              if answer && answer =~ /\An(o)?\z/i
-                add_it = false
+              add_it = if answer && answer =~ /\An(o)?\z/i
+                false
+              elsif ENV.fetch("force", "").to_s =~ ENV_TRUE_RE
+                true
               else
-                add_it = if ENV.fetch("force", "").to_s =~ ENV_TRUE_RE
-                  true
-                else
-                  answer.nil? || answer.empty? || answer =~ /\Ay(es)?\z/i
-                end
+                answer.nil? || answer.empty? || answer =~ /\Ay(es)?\z/i
               end
               if add_it
                 FileUtils.mkdir_p(File.dirname(gitignore_path))

--- a/lib/kettle/dev/template_helpers.rb
+++ b/lib/kettle/dev/template_helpers.rb
@@ -42,9 +42,13 @@ module Kettle
         print("#{prompt} #{default ? "[Y/n]" : "[y/N]"}: ")
         ans = Kettle::Dev::InputAdapter.gets&.strip
         ans = "" if ans.nil?
+        # Normalize explicit no first
+        return false if ans =~ /\An(o)?\z/i
         if default
+          # Empty -> default true; explicit yes -> true; anything else -> false
           ans.empty? || ans =~ /\Ay(es)?\z/i
         else
+          # Empty -> default false; explicit yes -> true; others (including garbage) -> false
           ans =~ /\Ay(es)?\z/i
         end
       end

--- a/spec/kettle/dev/setup_cli_more_spec.rb
+++ b/spec/kettle/dev/setup_cli_more_spec.rb
@@ -34,10 +34,14 @@ RSpec.describe Kettle::Dev::SetupCLI do
   end
 
   it "--force sets ENV['force']=true for in-process auto-yes prompts" do
-    # stubbed_env context ensures cleanup
-    expect(ENV["force"]).to be_nil
-    _cli = described_class.new(["--force"]) # parse! runs in initialize
-    expect(ENV["force"]).to eq("true")
+    # Ensure we clean up ENV["force"] since SetupCLI writes directly to ENV
+    begin
+      expect(ENV["force"]).to be_nil
+      _cli = described_class.new(["--force"]) # parse! runs in initialize
+      expect(ENV["force"]).to eq("true")
+    ensure
+      ENV.delete("force")
+    end
   end
 
   describe "#debug" do

--- a/spec/kettle/dev/setup_cli_more_spec.rb
+++ b/spec/kettle/dev/setup_cli_more_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Kettle::Dev::SetupCLI do
     end
   end
 
+  it "--force sets ENV['force']=true for in-process auto-yes prompts" do
+    # stubbed_env context ensures cleanup
+    expect(ENV["force"]).to be_nil
+    _cli = described_class.new(["--force"]) # parse! runs in initialize
+    expect(ENV["force"]).to eq("true")
+  end
+
   describe "#debug" do
     it "prints when DEBUG=true", :check_output do
       stub_env("DEBUG" => "true")

--- a/spec/kettle/dev/template_helpers_spec.rb
+++ b/spec/kettle/dev/template_helpers_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe Kettle::Dev::TemplateHelpers do
   end
 
   describe "::ask" do
+    before do
+      # Ensure force mode is not active for these interactive-path tests
+      stub_env("force" => "false")
+    end
     def simulate_input(str)
       allow(Kettle::Dev::InputAdapter).to receive(:gets).and_return(str)
     end

--- a/spec/kettle/dev/template_helpers_spec.rb
+++ b/spec/kettle/dev/template_helpers_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Kettle::Dev::TemplateHelpers do
       # Ensure force mode is not active for these interactive-path tests
       stub_env("force" => "false")
     end
+
     def simulate_input(str)
       allow(Kettle::Dev::InputAdapter).to receive(:gets).and_return(str)
     end


### PR DESCRIPTION
- [x] kettle-dev-setup now honors `--force` option