### PR TITLE
🎨 use current x_std_libs modular gemfile for all appraisals that are …

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -125,7 +125,7 @@ end
 
 # Only run security audit on the latest version of Ruby
 appraise "audit" do
-  eval_gemfile "modular/x_std_libs/r3/libs.gemfile"
+  eval_gemfile "modular/x_std_libs.gemfile"
   # Dependencies injected by the kettle-dev-setup script & kettle:dev:install rake task
   #  eval_gemfile "modular/injected.gemfile"
 end
@@ -135,7 +135,7 @@ appraise "coverage" do
   eval_gemfile "modular/coverage.gemfile"
   eval_gemfile "modular/optional.gemfile"
   eval_gemfile "modular/recording/r3/recording.gemfile"
-  eval_gemfile "modular/x_std_libs/r3/libs.gemfile"
+  eval_gemfile "modular/x_std_libs.gemfile"
   # Dependencies injected by the kettle-dev-setup script & kettle:dev:install rake task
   #  eval_gemfile "modular/injected.gemfile"
 end

--- a/Appraisals
+++ b/Appraisals
@@ -86,7 +86,7 @@ end
 
 appraise "ruby-2-7" do
   eval_gemfile "modular/recording/r2.5/recording.gemfile"
-  eval_gemfile "modular/x_std_libs/r3.1/libs.gemfile"
+  eval_gemfile "modular/x_std_libs/r2/libs.gemfile"
   # Dependencies injected by the kettle-dev-setup script & kettle:dev:install rake task
   #  eval_gemfile "modular/injected.gemfile"
 end

--- a/Appraisals.example
+++ b/Appraisals.example
@@ -83,18 +83,18 @@ end
 
 # Only run security audit on the latest version of Ruby
 appraise "audit" do
-  eval_gemfile "modular/x_std_libs/r3/libs.gemfile"
+  eval_gemfile "modular/x_std_libs.gemfile"
 end
 
 # Only run coverage on the latest version of Ruby
 appraise "coverage" do
   eval_gemfile "modular/coverage.gemfile"
   eval_gemfile "modular/optional.gemfile"
-  eval_gemfile "modular/x_std_libs/r3/libs.gemfile"
+  eval_gemfile "modular/x_std_libs.gemfile"
 end
 
 # Only run linter on the latest version of Ruby (but, in support of oldest supported Ruby version)
 appraise "style" do
   eval_gemfile "modular/style.gemfile"
-  eval_gemfile "modular/x_std_libs/r3/libs.gemfile"
+  eval_gemfile "modular/x_std_libs.gemfile"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please file a bug if you notice a violation of semantic versioning.
 ## [Unreleased]
 ### Added
 ### Changed
+- use current x_std_libs modular gemfile for all appraisals that are pinned to current ruby
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please file a bug if you notice a violation of semantic versioning.
 ### Added
 ### Changed
 - use current x_std_libs modular gemfile for all appraisals that are pinned to current ruby
+- fix appraisals for Ruby v2 to use correct version of erb
 ### Deprecated
 ### Removed
 ### Fixed

--- a/gemfiles/audit.gemfile
+++ b/gemfiles/audit.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gemspec path: "../"
 
-eval_gemfile("modular/x_std_libs/r3/libs.gemfile")
+eval_gemfile("modular/x_std_libs.gemfile")

--- a/gemfiles/coverage.gemfile
+++ b/gemfiles/coverage.gemfile
@@ -10,4 +10,4 @@ eval_gemfile("modular/optional.gemfile")
 
 eval_gemfile("modular/recording/r3/recording.gemfile")
 
-eval_gemfile("modular/x_std_libs/r3/libs.gemfile")
+eval_gemfile("modular/x_std_libs.gemfile")

--- a/gemfiles/ruby_2_7.gemfile
+++ b/gemfiles/ruby_2_7.gemfile
@@ -6,4 +6,4 @@ gemspec path: "../"
 
 eval_gemfile("modular/recording/r2.5/recording.gemfile")
 
-eval_gemfile("modular/x_std_libs/r3.1/libs.gemfile")
+eval_gemfile("modular/x_std_libs/r2/libs.gemfile")


### PR DESCRIPTION
…pinned to current ruby

- [x] fix appraisals for Ruby to use correct version of erb
