### PR TITLE
Allow release CI workflow subsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Please file a bug if you notice a violation of semantic versioning.
 
 ### Added
 
+- `kettle-release` now accepts `--ci-workflows` and
+  `K_RELEASE_CI_WORKFLOWS` to monitor an explicit workflow subset at the CI
+  wait step while retaining the default behavior of waiting for all applicable
+  workflows.
+
 ### Changed
 
 ### Deprecated

--- a/exe/kettle-release
+++ b/exe/kettle-release
@@ -43,7 +43,7 @@ end
 # Do not guard with __FILE__ == $PROGRAM_NAME because binstubs use Kernel.load.
 if ARGV.include?("-h") || ARGV.include?("--help")
   puts <<~USAGE
-    Usage: kettle-release [--version VERSION] [--local-ci] [--appraisal-update] [--skip-bundle-audit] [--skip-steps STEPS] [start_step=<0-19>]
+    Usage: kettle-release [--version VERSION] [--local-ci] [--appraisal-update] [--skip-bundle-audit] [--skip-steps STEPS] [--ci-workflows WORKFLOWS] [start_step=<0-19>]
 
     Automates the release flow for a Ruby gem in the host project.
 
@@ -81,6 +81,7 @@ if ARGV.include?("-h") || ARGV.include?("--help")
       --version VERSION           # Use this version instead of detecting VERSION from lib/**/version.rb
       --appraisal-update          # Use slower appraisal:update instead of default appraisal:generate
       --skip-bundle-audit         # Skip bundle:audit/update during release rake checks
+      --ci-workflows WORKFLOWS    # Comma-separated workflow files or stems to monitor at CI step 10
       --local-ci                  # Sensitive release mode: run act locally, publish before any git push,
                                   # create the git tag locally, then push commits and tags after publish
 
@@ -89,6 +90,7 @@ if ARGV.include?("-h") || ARGV.include?("--help")
       GEM_CERT_USER=<user>        # Select certs/<user>.pem for signing
       K_RELEASE_LOCAL_CI=ask|1|0  # Use 'act' locally before push; 'ask' prompts, '1' forces, default off
       K_RELEASE_LOCAL_CI_WORKFLOW # Name of workflow (without .yml) for local CI; defaults to locked_deps or first
+      K_RELEASE_CI_WORKFLOWS      # Comma-separated workflow files or stems to monitor at CI step 10
       KETTLE_RELEASE_APPRAISAL_TASK=appraisal:update
                                   # Use slower appraisal:update instead of default appraisal:generate
       KETTLE_DEV_SKIP_BUNDLE_AUDIT=true
@@ -145,6 +147,24 @@ def extract_skip_steps_arg!(argv)
   skip_steps
 end
 
+def extract_ci_workflows_arg!(argv)
+  workflows = nil
+  if (idx = argv.index("--ci-workflows"))
+    workflows = argv[idx + 1]
+    Kettle::Dev::ExitAdapter.abort("--ci-workflows requires a comma-separated workflow list") if workflows.to_s.empty?
+    argv.slice!(idx, 2)
+  end
+  argv.delete_if do |arg|
+    if arg.start_with?("--ci-workflows=", "ci_workflows=")
+      workflows = arg.split("=", 2)[1]
+      true
+    else
+      false
+    end
+  end
+  workflows
+end
+
 local_ci = ARGV.include?("--local-ci")
 appraisal_task = ARGV.delete("--appraisal-update") ? "appraisal:update" : nil
 skip_bundle_audit = !!ARGV.delete("--skip-bundle-audit")
@@ -152,9 +172,10 @@ start_step_arg = ARGV.find { |a| a.start_with?("start_step=") }
 start_step = start_step_arg ? start_step_arg.split("=", 2)[1].to_i : 0
 version_override = extract_version_arg!(ARGV)
 skip_steps = extract_skip_steps_arg!(ARGV)
+ci_workflows = extract_ci_workflows_arg!(ARGV)
 
 begin
-  Kettle::Dev::ReleaseCLI.new(start_step: start_step, local_ci: local_ci, version: version_override, appraisal_task: appraisal_task, skip_steps: skip_steps, skip_bundle_audit: skip_bundle_audit).run
+  Kettle::Dev::ReleaseCLI.new(start_step: start_step, local_ci: local_ci, version: version_override, appraisal_task: appraisal_task, skip_steps: skip_steps, skip_bundle_audit: skip_bundle_audit, ci_workflows: ci_workflows).run
 rescue LoadError => e
   warn("#{script_basename}: could not load dependency: #{e.class}: #{e.message}")
   warn(Array(e.backtrace).join("\n")) if ENV["DEBUG"]

--- a/lib/kettle/dev/ci_monitor.rb
+++ b/lib/kettle/dev/ci_monitor.rb
@@ -47,9 +47,9 @@ module Kettle
       #
       # @param restart_hint [String] guidance command shown on failure
       # @return [void]
-      def monitor_all!(restart_hint: "bundle exec kettle-release start_step=10")
+      def monitor_all!(restart_hint: "bundle exec kettle-release start_step=10", workflows: nil)
         checks_any = false
-        checks_any |= monitor_github_internal!(restart_hint: restart_hint)
+        checks_any |= monitor_github_internal!(restart_hint: restart_hint, workflows: workflows)
         checks_any |= monitor_gitlab_internal!(restart_hint: restart_hint)
         abort("CI configuration not detected (GitHub or GitLab). Ensure CI is configured and remotes point to the correct hosts.") unless checks_any
       end
@@ -269,9 +269,9 @@ module Kettle
 
       # -- internals (abort-on-failure legacy paths used elsewhere) --
 
-      def monitor_github_internal!(restart_hint:)
+      def monitor_github_internal!(restart_hint:, workflows: nil)
         root = Kettle::Dev::CIHelpers.project_root
-        workflows = Kettle::Dev::CIHelpers.workflows_list(root)
+        workflows = Array(workflows).empty? ? Kettle::Dev::CIHelpers.workflows_list(root) : Array(workflows)
         gh_remote = preferred_github_remote
         return false unless gh_remote && !workflows.empty?
 

--- a/lib/kettle/dev/release_cli.rb
+++ b/lib/kettle/dev/release_cli.rb
@@ -108,12 +108,13 @@ module Kettle
 
       public
 
-      def initialize(start_step: 0, local_ci: false, version: nil, appraisal_task: nil, skip_steps: nil, skip_bundle_audit: nil)
+      def initialize(start_step: 0, local_ci: false, version: nil, appraisal_task: nil, skip_steps: nil, skip_bundle_audit: nil, ci_workflows: nil)
         @root = Kettle::Dev::CIHelpers.project_root
         @git = Kettle::Dev::GitAdapter.new
         @start_step = (start_step || 0).to_i
         @start_step = 0 if @start_step < 0
         @skip_steps = normalize_skip_steps(skip_steps)
+        @ci_workflows = normalize_ci_workflows(ci_workflows || ENV["K_RELEASE_CI_WORKFLOWS"])
         @local_ci = !!local_ci
         @skip_bundle_audit = truthy_value?(skip_bundle_audit) || truthy_value?(ENV["KETTLE_DEV_SKIP_BUNDLE_AUDIT"])
         @version_override = Kettle::Dev::Versioning.normalize_explicit_version(version)
@@ -403,6 +404,11 @@ module Kettle
 
           step
         end.uniq
+      end
+
+      def normalize_ci_workflows(value)
+        workflows = Array(value).flat_map { |part| part.to_s.split(",") }.map(&:strip).reject(&:empty?)
+        workflows.map { |workflow| workflow.match?(/\.ya?ml\z/) ? workflow : "#{workflow}.yml" }.uniq
       end
 
       private
@@ -714,7 +720,7 @@ module Kettle
 
       def monitor_workflows_after_push!
         # Use abort-on-failure CI monitor to match historical behavior and specs
-        Kettle::Dev::CIMonitor.monitor_all!(restart_hint: "bundle exec kettle-release start_step=10")
+        Kettle::Dev::CIMonitor.monitor_all!(restart_hint: "bundle exec kettle-release start_step=10", workflows: @ci_workflows)
       end
 
       def run_cmd!(cmd)

--- a/spec/kettle/dev/ci_monitor_spec.rb
+++ b/spec/kettle/dev/ci_monitor_spec.rb
@@ -104,6 +104,28 @@ RSpec.describe Kettle::Dev::CIMonitor do
       expect { described_class.monitor_all!(restart_hint: "hint") }.not_to raise_error
     end
 
+    it "monitors an explicit workflow subset when provided", :check_output do
+      allow(helpers).to receive_messages(
+        project_root: Dir.pwd,
+        current_branch: "main",
+        current_head_sha: "abc123"
+      )
+      expect(helpers).not_to receive(:workflows_list)
+      allow(described_class).to receive_messages(
+        preferred_github_remote: "origin",
+        remote_url: "https://github.com/me/repo.git"
+      )
+      allow(helpers).to receive(:latest_run).with(owner: "me", repo: "repo", workflow_file: "current.yml", branch: "main", require_head: true, head_sha: "abc123").and_return(
+        {"status" => "completed", "conclusion" => "success", "html_url" => "https://github.com/me/repo/actions/runs/2", "id" => 2, "head_sha" => "abc123"}
+      )
+      allow(helpers).to receive(:success?) { |run| run && run["conclusion"] == "success" }
+      allow(helpers).to receive(:failed?) { |run| run && run["conclusion"] == "failure" }
+      stub_env("K_RELEASE_CI_INITIAL_SLEEP" => "0")
+      allow(described_class).to receive(:sleep)
+
+      expect { described_class.monitor_all!(restart_hint: "hint", workflows: ["current.yml"]) }.not_to raise_error
+    end
+
     it "times out when GitHub never starts a run for local HEAD", :check_output do
       allow(helpers).to receive_messages(
         project_root: Dir.pwd,

--- a/spec/kettle/dev/release_cli_spec.rb
+++ b/spec/kettle/dev/release_cli_spec.rb
@@ -655,6 +655,31 @@ RSpec.describe Kettle::Dev::ReleaseCLI do
         expect { cli.send(:monitor_workflows_after_push!) }.not_to raise_error
       end
 
+      it "passes an explicit normalized workflow subset to the CI monitor" do
+        release_cli = described_class.new(ci_workflows: "current,style.yml")
+        allow(Kettle::Dev::CIMonitor).to receive(:monitor_all!)
+
+        release_cli.send(:monitor_workflows_after_push!)
+
+        expect(Kettle::Dev::CIMonitor).to have_received(:monitor_all!).with(
+          restart_hint: "bundle exec kettle-release start_step=10",
+          workflows: %w[current.yml style.yml]
+        )
+      end
+
+      it "uses K_RELEASE_CI_WORKFLOWS when no explicit workflow subset is passed" do
+        stub_env("K_RELEASE_CI_WORKFLOWS" => "current,style.yml")
+        release_cli = described_class.new
+        allow(Kettle::Dev::CIMonitor).to receive(:monitor_all!)
+
+        release_cli.send(:monitor_workflows_after_push!)
+
+        expect(Kettle::Dev::CIMonitor).to have_received(:monitor_all!).with(
+          restart_hint: "bundle exec kettle-release start_step=10",
+          workflows: %w[current.yml style.yml]
+        )
+      end
+
       it "aborts when a GitHub workflow fails" do
         allow(ci_helpers).to receive(:workflows_list).and_return(["ci.yml"])
         allow(File).to receive(:exist?).and_call_original


### PR DESCRIPTION
## Summary
- add `kettle-release --ci-workflows` and `K_RELEASE_CI_WORKFLOWS`
- pass an explicit workflow subset to the CI monitor when requested
- keep the default release behavior waiting for all applicable workflows

## Validation
- `K_SOUP_COV_DO=false bundle exec kettle-test spec/kettle/dev/ci_monitor_spec.rb spec/kettle/dev/release_cli_spec.rb`
- `K_SOUP_COV_DO=false bundle exec kettle-test`
- `bin/rake rubocop_gradual:autocorrect`
- `git diff --check`