### PR TITLE
Address release workflow subset review feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Please file a bug if you notice a violation of semantic versioning.
 
 ### Fixed
 
+- `kettle-release --ci-workflows` now rejects a missing value when the next
+  token is another flag, and the release CI workflow subset APIs now have
+  matching RBS signatures.
+
 ### Security
 
 ## [2.3.5] - 2026-07-16

--- a/exe/kettle-release
+++ b/exe/kettle-release
@@ -151,12 +151,15 @@ def extract_ci_workflows_arg!(argv)
   workflows = nil
   if (idx = argv.index("--ci-workflows"))
     workflows = argv[idx + 1]
-    Kettle::Dev::ExitAdapter.abort("--ci-workflows requires a comma-separated workflow list") if workflows.to_s.empty?
+    if workflows.to_s.empty? || workflows.to_s.start_with?("-")
+      Kettle::Dev::ExitAdapter.abort("--ci-workflows requires a comma-separated workflow list")
+    end
     argv.slice!(idx, 2)
   end
   argv.delete_if do |arg|
     if arg.start_with?("--ci-workflows=", "ci_workflows=")
       workflows = arg.split("=", 2)[1]
+      Kettle::Dev::ExitAdapter.abort("--ci-workflows requires a comma-separated workflow list") if workflows.to_s.empty?
       true
     else
       false

--- a/lib/kettle/dev/ci_monitor.rb
+++ b/lib/kettle/dev/ci_monitor.rb
@@ -47,7 +47,7 @@ module Kettle
       #
       # @param restart_hint [String] guidance command shown on failure
       # @return [void]
-      def monitor_all!(restart_hint: "bundle exec kettle-release start_step=10", workflows: nil, **_options)
+      def monitor_all!(restart_hint: "bundle exec kettle-release start_step=10", workflows: nil, **options)
         checks_any = false
         checks_any |= monitor_github_internal!(restart_hint: restart_hint, workflows: workflows)
         checks_any |= monitor_gitlab_internal!(restart_hint: restart_hint)

--- a/lib/kettle/dev/ci_monitor.rb
+++ b/lib/kettle/dev/ci_monitor.rb
@@ -47,7 +47,7 @@ module Kettle
       #
       # @param restart_hint [String] guidance command shown on failure
       # @return [void]
-      def monitor_all!(restart_hint: "bundle exec kettle-release start_step=10", workflows: nil)
+      def monitor_all!(restart_hint: "bundle exec kettle-release start_step=10", workflows: nil, **_options)
         checks_any = false
         checks_any |= monitor_github_internal!(restart_hint: restart_hint, workflows: workflows)
         checks_any |= monitor_gitlab_internal!(restart_hint: restart_hint)

--- a/lib/kettle/dev/release_cli.rb
+++ b/lib/kettle/dev/release_cli.rb
@@ -108,7 +108,7 @@ module Kettle
 
       public
 
-      def initialize(start_step: 0, local_ci: false, version: nil, appraisal_task: nil, skip_steps: nil, skip_bundle_audit: nil, ci_workflows: nil, **_options)
+      def initialize(start_step: 0, local_ci: false, version: nil, appraisal_task: nil, skip_steps: nil, skip_bundle_audit: nil, ci_workflows: nil, **options)
         @root = Kettle::Dev::CIHelpers.project_root
         @git = Kettle::Dev::GitAdapter.new
         @start_step = (start_step || 0).to_i

--- a/lib/kettle/dev/release_cli.rb
+++ b/lib/kettle/dev/release_cli.rb
@@ -108,7 +108,7 @@ module Kettle
 
       public
 
-      def initialize(start_step: 0, local_ci: false, version: nil, appraisal_task: nil, skip_steps: nil, skip_bundle_audit: nil, ci_workflows: nil)
+      def initialize(start_step: 0, local_ci: false, version: nil, appraisal_task: nil, skip_steps: nil, skip_bundle_audit: nil, ci_workflows: nil, **_options)
         @root = Kettle::Dev::CIHelpers.project_root
         @git = Kettle::Dev::GitAdapter.new
         @start_step = (start_step || 0).to_i

--- a/sig/kettle/dev/ci_monitor.rbs
+++ b/sig/kettle/dev/ci_monitor.rbs
@@ -2,7 +2,7 @@ module Kettle
   module Dev
     module CIMonitor
       def self.status_emoji: (String? status, String? conclusion) -> String
-      def self.monitor_all!: (?restart_hint: String) -> void
+      def self.monitor_all!: (?restart_hint: String, ?workflows: Array[String]?, **untyped) -> void
       def self.monitor_gitlab!: (?restart_hint: String) -> bool
       def self.collect_all: () -> { github: Array[untyped], gitlab: untyped? }
       def self.summarize_results: ({ github: Array[untyped], gitlab: untyped? }) -> bool

--- a/sig/kettle/dev/release_cli.rbs
+++ b/sig/kettle/dev/release_cli.rbs
@@ -1,7 +1,7 @@
 module Kettle
   module Dev
     class ReleaseCLI
-      def initialize: (?start_step: Integer) -> void
+      def initialize: (?start_step: Integer, ?local_ci: bool, ?version: String?, ?appraisal_task: String?, ?skip_steps: untyped, ?skip_bundle_audit: bool?, ?ci_workflows: untyped, **untyped) -> void
       def run: () -> void
 
       private


### PR DESCRIPTION
## Summary
- reject missing --ci-workflows values when the next token is another flag
- allow trailing keyword arguments on release CI workflow subset APIs
- update RBS signatures for the new release CI workflow subset keywords

## Validation
- K_SOUP_COV_DO=false bundle exec kettle-test spec/kettle/dev/ci_monitor_spec.rb spec/kettle/dev/release_cli_spec.rb
- bin/rake rubocop_gradual:autocorrect
- bundle exec rbs validate
- git diff --check