### PR TITLE
Canonicalize equivalent GHA version tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Please file a bug if you notice a violation of semantic versioning.
 
 ### Fixed
 
+- `kettle-gha-sha-pins` now canonicalizes duplicate equivalent action tags,
+  preferring explicit release tags such as `v7.0.0` over major-line aliases
+  such as `v7`, so adjacent version comments do not flip between spellings.
+
 ### Security
 
 ## [2.3.6] - 2026-07-17

--- a/lib/kettle/dev/gha_sha_pins_cli.rb
+++ b/lib/kettle/dev/gha_sha_pins_cli.rb
@@ -1222,7 +1222,7 @@ module Kettle
         def canonicalize_equivalent_release_versions(releases)
           groups = []
           releases.each do |release|
-            group = groups.find { |entries| entries.first[:version_obj] == release[:version_obj] }
+            group = groups.find { |entries| equivalent_release_tag?(entries.first, release) }
             if group
               group << release
             else
@@ -1231,6 +1231,13 @@ module Kettle
           end
 
           groups.map { |entries| entries.max_by { |entry| release_version_specificity(entry) } }
+        end
+
+        def equivalent_release_tag?(left, right)
+          left[:version_obj] == right[:version_obj] &&
+            left[:sha] &&
+            right[:sha] &&
+            left[:sha] == right[:sha]
         end
 
         def release_version_specificity(entry)

--- a/lib/kettle/dev/gha_sha_pins_cli.rb
+++ b/lib/kettle/dev/gha_sha_pins_cli.rb
@@ -1212,10 +1212,38 @@ module Kettle
             }
           end
           releases.concat(tag_versions)
+          releases = canonicalize_equivalent_release_versions(releases)
 
           releases.sort_by! { |release| release[:version_obj] }
           releases.reverse!
           releases
+        end
+
+        def canonicalize_equivalent_release_versions(releases)
+          groups = []
+          releases.each do |release|
+            group = groups.find { |entries| entries.first[:version_obj] == release[:version_obj] }
+            if group
+              group << release
+            else
+              groups << [release]
+            end
+          end
+
+          groups.map { |entries| entries.max_by { |entry| release_version_specificity(entry) } }
+        end
+
+        def release_version_specificity(entry)
+          text = entry.fetch(:tag).to_s.sub(/\A[vV]/, "")
+          release_text, suffix = text.split(/[-.](?=[A-Za-z])/, 2)
+          numeric_segments = release_text.to_s.split(".").take_while { |part| part.match?(/\A\d+\z/) }
+
+          [
+            numeric_segments.length,
+            suffix ? 0 : 1,
+            text.length,
+            entry.fetch(:tag).to_s
+          ]
         end
 
         def parse_release_version_text(value)

--- a/lib/kettle/dev/gha_sha_pins_cli.rb
+++ b/lib/kettle/dev/gha_sha_pins_cli.rb
@@ -35,6 +35,23 @@ module Kettle
       VERSION_COMMENT_SUFFIX_RE = /\A\s+#\s*v?(?<version>\d+(?:\.\d+\.\d+(?:[-.]?[0-9A-Za-z.-]+)?)?)/
       VERSION_COMMENT_REPLACEMENT_RE = /\A(?<prefix>\s+#\s*)v?\d+(?:\.\d+\.\d+(?:[-.]?[0-9A-Za-z.-]+)?)?/
 
+      def self.release_version_sort_key(entry)
+        [entry.fetch(:version_obj), *release_version_specificity(entry)]
+      end
+
+      def self.release_version_specificity(entry)
+        text = entry.fetch(:tag).to_s.sub(/\A[vV]/, "")
+        release_text, suffix = text.split(/[-.](?=[A-Za-z])/, 2)
+        numeric_segments = release_text.to_s.split(".").take_while { |part| part.match?(/\A\d+\z/) }
+
+        [
+          numeric_segments.length,
+          suffix ? 0 : 1,
+          text.length,
+          entry.fetch(:tag).to_s
+        ]
+      end
+
       def initialize(argv, err: $stderr)
         @argv = argv
         @err = err
@@ -521,7 +538,7 @@ module Kettle
           end
         end
 
-        candidates.max_by { |entry| entry[:version_obj] }
+        candidates.max_by { |entry| release_version_sort_key(entry) }
       end
 
       def major_line_version?(value)
@@ -538,7 +555,7 @@ module Kettle
               entry[:version_obj] > current &&
               (!entry[:version_obj].prerelease? || current.prerelease?)
           end
-          .max_by { |entry| entry[:version_obj] }
+          .max_by { |entry| release_version_sort_key(entry) }
       end
 
       def determine_upgrade_plan(old_ref:, repo_ref:, versions:, upgrade_level:, client:)
@@ -643,6 +660,10 @@ module Kettle
         sha = client.commit_sha(repo_ref, entry[:tag])
         entry[:sha] = sha
         sha
+      end
+
+      def release_version_sort_key(entry)
+        self.class.release_version_sort_key(entry)
       end
 
       def short_sha?(candidate)
@@ -1061,10 +1082,10 @@ module Kettle
           full_semver_entries = entries.reject { |entry| major_line_version?(entry[:version]) }
           {
             "patch" => full_semver_entries.group_by { |entry| entry[:version_obj].segments[0, 2].join(".") }
-              .transform_values { |group| serialize_target(group.max_by { |entry| entry[:version_obj] }) },
+              .transform_values { |group| serialize_target(group.max_by { |entry| GhaShaPinsCLI.release_version_sort_key(entry) }) },
             "minor" => full_semver_entries.group_by { |entry| entry[:version_obj].segments[0].to_s }
-              .transform_values { |group| serialize_target(group.max_by { |entry| entry[:version_obj] }) },
-            "major" => {"*" => serialize_target(entries.max_by { |entry| entry[:version_obj] })}
+              .transform_values { |group| serialize_target(group.max_by { |entry| GhaShaPinsCLI.release_version_sort_key(entry) }) },
+            "major" => {"*" => serialize_target(entries.max_by { |entry| GhaShaPinsCLI.release_version_sort_key(entry) })}
           }
         end
 
@@ -1214,7 +1235,7 @@ module Kettle
           releases.concat(tag_versions)
           releases = canonicalize_equivalent_release_versions(releases)
 
-          releases.sort_by! { |release| release[:version_obj] }
+          releases.sort_by! { |release| GhaShaPinsCLI.release_version_sort_key(release) }
           releases.reverse!
           releases
         end
@@ -1230,7 +1251,7 @@ module Kettle
             end
           end
 
-          groups.map { |entries| entries.max_by { |entry| release_version_specificity(entry) } }
+          groups.map { |entries| entries.max_by { |entry| GhaShaPinsCLI.release_version_sort_key(entry) } }
         end
 
         def equivalent_release_tag?(left, right)
@@ -1238,19 +1259,6 @@ module Kettle
             left[:sha] &&
             right[:sha] &&
             left[:sha] == right[:sha]
-        end
-
-        def release_version_specificity(entry)
-          text = entry.fetch(:tag).to_s.sub(/\A[vV]/, "")
-          release_text, suffix = text.split(/[-.](?=[A-Za-z])/, 2)
-          numeric_segments = release_text.to_s.split(".").take_while { |part| part.match?(/\A\d+\z/) }
-
-          [
-            numeric_segments.length,
-            suffix ? 0 : 1,
-            text.length,
-            entry.fetch(:tag).to_s
-          ]
         end
 
         def parse_release_version_text(value)

--- a/spec/kettle/dev/gha_sha_pins_cli_spec.rb
+++ b/spec/kettle/dev/gha_sha_pins_cli_spec.rb
@@ -318,12 +318,12 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
 
       versions = client.versions_for_repo("foo/bar")
 
-      expect(versions).to include(
+      expect(versions).to match([
         include(tag: "v2", version: "2", sha: "d" * 40),
         include(tag: "v1.0.1", version: "1.0.1", sha: "b" * 40),
         include(tag: "v1.0.0", version: "1.0.0", sha: "a" * 40),
         include(tag: "v1", version: "1", sha: "c" * 40)
-      )
+      ])
     end
 
     it "canonicalizes equivalent release and major-line tags to the more explicit version spelling" do
@@ -341,6 +341,27 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
       expect(versions).to contain_exactly(
         include(tag: "v7.0.0", version: "7.0.0", sha: "a" * 40)
       )
+    end
+
+    it "prefers the concrete patch tag when a moving major-line tag points to the same SHA" do
+      client = described_class.new(token: nil, api_base: Kettle::Dev::GhaShaPinsCLI::API_BASE, user_agent: "kettle-gha-sha-pins")
+      allow(client).to receive(:request_json).with("/repos/foo/bar/releases?per_page=100").and_return([
+        {"tag_name" => "v7.0.0", "prerelease" => false},
+        {"tag_name" => "v7.0.1", "prerelease" => false}
+      ])
+      allow(client).to receive(:request_json).with("/repos/foo/bar/git/matching-refs/tags/").and_return([
+        {"ref" => "refs/tags/v7.0.0", "object" => {"type" => "commit", "sha" => "a" * 40}},
+        {"ref" => "refs/tags/v7", "object" => {"type" => "commit", "sha" => "b" * 40}},
+        {"ref" => "refs/tags/v7.0.1", "object" => {"type" => "commit", "sha" => "b" * 40}}
+      ])
+
+      versions = client.versions_for_repo("foo/bar")
+
+      expect(versions).to match([
+        include(tag: "v7.0.1", version: "7.0.1", sha: "b" * 40),
+        include(tag: "v7.0.0", version: "7.0.0", sha: "a" * 40),
+        include(tag: "v7", version: "7", sha: "b" * 40)
+      ])
     end
 
     it "does not canonicalize equivalent version spellings when the tag SHA is unknown" do

--- a/spec/kettle/dev/gha_sha_pins_cli_spec.rb
+++ b/spec/kettle/dev/gha_sha_pins_cli_spec.rb
@@ -312,13 +312,31 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
       allow(client).to receive(:request_json).with("/repos/foo/bar/git/matching-refs/tags/").and_return([
         {"ref" => "refs/tags/v1.0.0", "object" => {"type" => "commit", "sha" => "a" * 40}},
         {"ref" => "refs/tags/v1.0.1", "object" => {"type" => "commit", "sha" => "b" * 40}},
-        {"ref" => "refs/tags/v1", "object" => {"type" => "commit", "sha" => "c" * 40}}
+        {"ref" => "refs/tags/v1", "object" => {"type" => "commit", "sha" => "c" * 40}},
+        {"ref" => "refs/tags/v2", "object" => {"type" => "commit", "sha" => "d" * 40}}
       ])
 
       versions = client.versions_for_repo("foo/bar")
 
-      expect(versions.map { |entry| entry[:version] }).to eq(%w[1.0.1 1 1.0.0])
-      expect(versions.map { |entry| entry[:sha] }).to eq(["b" * 40, "c" * 40, "a" * 40])
+      expect(versions.map { |entry| entry[:version] }).to eq(%w[2 1.0.1 1.0.0])
+      expect(versions.map { |entry| entry[:sha] }).to eq(["d" * 40, "b" * 40, "a" * 40])
+    end
+
+    it "canonicalizes equivalent release and major-line tags to the more explicit version spelling" do
+      client = described_class.new(token: nil, api_base: Kettle::Dev::GhaShaPinsCLI::API_BASE, user_agent: "kettle-gha-sha-pins")
+      allow(client).to receive(:request_json).with("/repos/foo/bar/releases?per_page=100").and_return([
+        {"tag_name" => "v7.0.0", "prerelease" => false}
+      ])
+      allow(client).to receive(:request_json).with("/repos/foo/bar/git/matching-refs/tags/").and_return([
+        {"ref" => "refs/tags/v7", "object" => {"type" => "commit", "sha" => "a" * 40}},
+        {"ref" => "refs/tags/v7.0.0", "object" => {"type" => "commit", "sha" => "a" * 40}}
+      ])
+
+      versions = client.versions_for_repo("foo/bar")
+
+      expect(versions).to contain_exactly(
+        include(tag: "v7.0.0", version: "7.0.0", sha: "a" * 40)
+      )
     end
 
     it "defers annotated tag commit resolution until a specific version is needed" do
@@ -722,7 +740,7 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
       expect(File.read(workflow_path)).not_to include("# v1.2.0")
     end
 
-    it "updates major-line version comments once and stays clean on the next run" do
+    it "updates major-line version comments to the canonical explicit equivalent once and stays clean" do
       File.write(
         workflow_path,
         <<~YAML
@@ -738,7 +756,7 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
       cli_client = instance_double(described_class::GitHubClient)
       allow(described_class::GitHubClient).to receive(:new).and_return(cli_client)
       allow(cli_client).to receive(:versions_for_repo).with("foo/bar").and_return([
-        {tag: "v7", version_obj: Gem::Version.new("7"), version: "7", sha: "bbb"}
+        {tag: "v7.0.0", version_obj: Gem::Version.new("7.0.0"), version: "7.0.0", sha: "bbb"}
       ])
       allow(cli_client).to receive(:commit_sha).with("foo/bar", "bbb").and_return("bbb")
 
@@ -746,8 +764,35 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
       second_run = described_class.new(["--root", workflow_root, "--upgrade", "major", "--check"])
 
       expect(first_run.run!).to eq(0)
-      expect(File.read(workflow_path)).to include("uses: foo/bar@bbb # v7")
+      expect(File.read(workflow_path)).to include("uses: foo/bar@bbb # v7.0.0")
       expect(second_run.run!).to eq(0)
+    end
+
+    it "updates shorthand major-line version comments to the canonical explicit equivalent" do
+      File.write(
+        workflow_path,
+        <<~YAML
+          name: ci
+          on: [push]
+          jobs:
+            test:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: foo/bar@bbb # v7
+        YAML
+      )
+      cli_client = instance_double(described_class::GitHubClient)
+      allow(described_class::GitHubClient).to receive(:new).and_return(cli_client)
+      allow(cli_client).to receive(:versions_for_repo).with("foo/bar").and_return([
+        {tag: "v7.0.0", version_obj: Gem::Version.new("7.0.0"), version: "7.0.0", sha: "bbb"}
+      ])
+      allow(cli_client).to receive(:commit_sha).with("foo/bar", "bbb").and_return("bbb")
+
+      cli = described_class.new(["--root", workflow_root, "--upgrade", "major", "--write"])
+
+      expect(cli.run!).to eq(0)
+      expect(File.read(workflow_path)).to include("uses: foo/bar@bbb # v7.0.0")
+      expect(File.read(workflow_path)).not_to include("# v7\n")
     end
 
     it "calls GitHub release-version lookup for each workflow action when evaluating pins" do

--- a/spec/kettle/dev/gha_sha_pins_cli_spec.rb
+++ b/spec/kettle/dev/gha_sha_pins_cli_spec.rb
@@ -318,8 +318,12 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
 
       versions = client.versions_for_repo("foo/bar")
 
-      expect(versions.map { |entry| entry[:version] }).to eq(%w[2 1.0.1 1.0.0])
-      expect(versions.map { |entry| entry[:sha] }).to eq(["d" * 40, "b" * 40, "a" * 40])
+      expect(versions).to include(
+        include(tag: "v2", version: "2", sha: "d" * 40),
+        include(tag: "v1.0.1", version: "1.0.1", sha: "b" * 40),
+        include(tag: "v1.0.0", version: "1.0.0", sha: "a" * 40),
+        include(tag: "v1", version: "1", sha: "c" * 40)
+      )
     end
 
     it "canonicalizes equivalent release and major-line tags to the more explicit version spelling" do
@@ -336,6 +340,24 @@ RSpec.describe Kettle::Dev::GhaShaPinsCLI do
 
       expect(versions).to contain_exactly(
         include(tag: "v7.0.0", version: "7.0.0", sha: "a" * 40)
+      )
+    end
+
+    it "does not canonicalize equivalent version spellings when the tag SHA is unknown" do
+      client = described_class.new(token: nil, api_base: Kettle::Dev::GhaShaPinsCLI::API_BASE, user_agent: "kettle-gha-sha-pins")
+      allow(client).to receive(:request_json).with("/repos/foo/bar/releases?per_page=100").and_return([
+        {"tag_name" => "v7.0.0", "prerelease" => false}
+      ])
+      allow(client).to receive(:request_json).with("/repos/foo/bar/git/matching-refs/tags/").and_return([
+        {"ref" => "refs/tags/v7", "object" => {"type" => "tag", "sha" => "a" * 40}},
+        {"ref" => "refs/tags/v7.0.0", "object" => {"type" => "commit", "sha" => "b" * 40}}
+      ])
+
+      versions = client.versions_for_repo("foo/bar")
+
+      expect(versions).to contain_exactly(
+        include(tag: "v7", version: "7", sha: nil),
+        include(tag: "v7.0.0", version: "7.0.0", sha: "b" * 40)
       )
     end
 


### PR DESCRIPTION
## Summary

- collapse equivalent GitHub Action release tags before choosing the latest pin comment
- prefer explicit release spellings such as `v7.0.0` over major-line aliases such as `v7`
- cover major-line-only tags so aliases are still kept when no explicit equivalent exists

## Why

Some actions publish both a major-line alias and a full release tag pointing at the same SHA. Without canonicalizing equivalent versions, `kettle-gha-sha-pins` can flip adjacent comments between forms such as `# v7` and `# v7.0.0` depending on API/cache ordering.

## Verification

- `env K_SOUP_COV_MIN_HARD=false K_SOUP_COV_DO=false bundle exec kettle-test spec/kettle/dev/gha_sha_pins_cli_spec.rb`
- `bin/rake rubocop_gradual:autocorrect`
- `ruby -c lib/kettle/dev/gha_sha_pins_cli.rb`
- `git diff --check`
